### PR TITLE
Report hide keyboard

### DIFF
--- a/CosmeApp.xcodeproj/project.pbxproj
+++ b/CosmeApp.xcodeproj/project.pbxproj
@@ -1522,14 +1522,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 8Q7ZNNJG4G;
+				DEVELOPMENT_TEAM = 2G8PC2F294;
 				INFOPLIST_FILE = CosmeApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.4;
-				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.Alamofir;
+				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.Alamofir20200713a;
 				PRODUCT_NAME = Choupinet;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1542,14 +1542,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 8Q7ZNNJG4G;
+				DEVELOPMENT_TEAM = 2G8PC2F294;
 				INFOPLIST_FILE = CosmeApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.4;
-				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.Alamofire;
+				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.Alamofire20200713a;
 				PRODUCT_NAME = Choupinet;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/CosmeApp/Post/Review/CreateReviewViewController.swift
+++ b/CosmeApp/Post/Review/CreateReviewViewController.swift
@@ -49,23 +49,23 @@ extension CreateReviewViewController {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         switch imageViewType2 {
         case .first:
-            if let image = info[.originalImage] as? UIImage {
-                mainView.itemFirstImageVIew.image = image
+            if let firstImage = info[.originalImage] as? UIImage {
+                mainView.itemFirstImageVIew.image = firstImage
                 picker.dismiss(animated: true, completion: nil)
             }
         case .second:
-            if let image = info[.originalImage] as? UIImage {
-                mainView.itemSecondImageView.image = image
+            if let secondImage = info[.originalImage] as? UIImage {
+                mainView.itemSecondImageView.image = secondImage
                 picker.dismiss(animated: true, completion: nil)
             }
         case .third:
-            if let image = info[.originalImage] as? UIImage {
-                mainView.itemThirdImageView.image = image
+            if let therdImage = info[.originalImage] as? UIImage {
+                mainView.itemThirdImageView.image = therdImage
                 picker.dismiss(animated: true, completion: nil)
             }
         case .fourth:
-            if let image = info[.originalImage] as? UIImage {
-                mainView.itemFourthImageView.image = image
+            if let fourthImage = info[.originalImage] as? UIImage {
+                mainView.itemFourthImageView.image = fourthImage
                 picker.dismiss(animated: true, completion: nil)
             }
         default:
@@ -108,17 +108,17 @@ extension CreateReviewViewController:HeaderViewDelegate {
         
         
         var images:[UIImage] = []
-        if let image = mainView.itemFirstImageVIew.image {
-            images.append(image)
+        if let firsrImage = mainView.itemFirstImageVIew.image {
+            images.append(firsrImage)
         }
-        if let image = mainView.itemSecondImageView.image {
-            images.append(image)
+        if let secondImage = mainView.itemSecondImageView.image {
+            images.append(secondImage)
         }
-        if let image = mainView.itemThirdImageView.image {
-            images.append(image)
+        if let therdImage = mainView.itemThirdImageView.image {
+            images.append(therdImage)
         }
-        if let image = mainView.itemFourthImageView.image {
-            images.append(image)
+        if let fourthImage = mainView.itemFourthImageView.image {
+            images.append(fourthImage)
         }
         
         if let uid = Auth.auth().currentUser?.uid {

--- a/CosmeApp/Report/ReportDone/ReportDoneViewController.swift
+++ b/CosmeApp/Report/ReportDone/ReportDoneViewController.swift
@@ -31,6 +31,7 @@ extension ReportDoneViewController {
         setDelegate()
         setHeaderView()
         changeLabel()
+        hideKeybord()
     }
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -88,6 +89,15 @@ extension ReportDoneViewController {
         default:
             mainView.reportLabel.text = ""
         }
+    }
+    func hideKeybord() {
+        let hideTap : UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(hideKyeoboardTap))
+        hideTap.numberOfTapsRequired = 1
+        self.view.isUserInteractionEnabled = true
+        self.view.addGestureRecognizer(hideTap)
+    }
+    @objc func hideKyeoboardTap(recognizer : UITapGestureRecognizer){
+        self.view.endEditing(true)
     }
 }
 


### PR DESCRIPTION
通報画面（ReportDoneViewController）の画面外を触ることでキーボードを非表示にする処理を追加しました。

【目的】
ユーザーが投稿通報による報告ができなくなっていることで
運営が問題のある投稿を削除できなくなる。

【内容】
通報文章を書いた後に
通報ボタンを押せない状況が発生していたが、
ReportConeViewControllerにfunc hideKeyboard　という
ファンクションを追加したことで、
キーボードの外の画面を触ることで
キーボードを下げれるようになった。

【確認手順】

・タイムライン、検索、プロフィールページから
投稿詳細画面を開く
・投稿詳細画面の△に！のマークをタップし、通報画面へ遷移
・通報のジャンルを選択し、TextViewをタップしてキーボードを開く
・キーボード外の画面をタップしキーボードを下げる
